### PR TITLE
Return a more reasonable error message to user for failed auth

### DIFF
--- a/prefect/__init__.py
+++ b/prefect/__init__.py
@@ -291,7 +291,10 @@ class FordAPI:
             }
         }
         res = self.post(self.url("services/webLoginPS"), params)
-        self._token = res.json()["response"]["authToken"]
+        try:
+            self._token = res.json()["response"]["authToken"]
+        except Exception as e:
+            raise ValueError(f"Could not authenticate: {res.json()}") from e
 
     def get_vehicles(self) -> List["Vehicle"]:
         """


### PR DESCRIPTION
We used to return an unintuitive "KeyError" on a failed authentication (#4). The call to `FordAPI#authenticate` will now raise a ValueError along with the response's JSON payload (if any):

```
ValueError: Could not authenticate: {'error': {'code': '203'}}
```